### PR TITLE
Update Dockerfile to include 'ping'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM node:20-bullseye
 LABEL maintainer="acsdesk@protonmail.com"
 
-RUN apt-get update && apt-get install -y sudo supervisor git
+RUN apt-get update && apt-get install -y sudo supervisor git iputils-ping
 RUN mkdir -p /var/log/supervisor
 
 #RUN npm install -g --unsafe-perm genieacs@1.2.11


### PR DESCRIPTION
`node:20-bullseye` does not include the `ping` binary, like `node:18-buster` did.
We need to explicitly install it when building the docker container.