### PR TITLE
Add wget tool to Dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ FROM debian:bookworm-slim
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-      supervisor ca-certificates iputils-ping logrotate git \
+      supervisor ca-certificates iputils-ping logrotate git wget \
  && rm -rf /var/lib/apt/lists/*
 
 # Copy Node runtime and GenieACS artefacts from the build stage


### PR DESCRIPTION
I ran this Docker image, but the container status remained unhealthy. It turned out that the health check used wget, but when I checked, the Debian image did not have the wget tool. Therefore, this image must have the wget tool from the start.