### PR TITLE
chart: add externalMongodb.existingSecret for secret-sourced connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ helm install genieacs genieacs/genieacs \
   --set env.GENIEACS_UI_JWT_SECRET=your-secret-here
 ```
 
-To use an external MongoDB instead:
+To use an external MongoDB (connection string inline):
 
 ```bash
 helm install genieacs genieacs/genieacs \
@@ -138,6 +138,36 @@ helm install genieacs genieacs/genieacs \
   --set mongodb.enabled=false \
   --set externalMongodb.url=mongodb://your-mongo-host/genieacs
 ```
+
+To use an external MongoDB with the connection string sourced from a
+Kubernetes Secret (recommended for production — keeps credentials out
+of values files and out of the pod spec):
+
+```bash
+kubectl create secret generic genieacs-mongodb \
+  --namespace genieacs \
+  --from-literal=connectionString="mongodb+srv://user:pass@cluster.example.net/genieacs?retryWrites=true"
+
+helm install genieacs genieacs/genieacs \
+  --namespace genieacs \
+  --create-namespace \
+  --set mongodb.enabled=false \
+  --set externalMongodb.existingSecret=genieacs-mongodb \
+  --set externalMongodb.secretKey=connectionString
+```
+
+This pattern integrates with External Secrets Operator, Sealed Secrets,
+Vault, and operators that write connection details to a Kubernetes
+Secret (MongoDB Atlas Operator, MongoDB Controllers for Kubernetes
+(MCK), the Percona Operator).
+
+> **Production note:** The bundled Bitnami MongoDB subchart is intended
+> for development and evaluation only. For production deployments, run
+> MongoDB separately — managed (MongoDB Atlas), operator-managed
+> ([MCK](https://github.com/mongodb/mongodb-kubernetes),
+> [Percona Operator for MongoDB](https://github.com/percona/percona-server-mongodb-operator)),
+> or self-hosted — and point the chart at it using
+> `externalMongodb.existingSecret`.
 
 #### Using Helmfile
 
@@ -182,9 +212,14 @@ mongodb:
     enabled: true
     size: 8Gi
 
-# Used when mongodb.enabled is false
+# Used when mongodb.enabled is false (bring your own MongoDB).
+# Set either `url` directly, or `existingSecret` + `secretKey` to
+# source the connection string from a Kubernetes Secret (recommended
+# for production). If both are set, `existingSecret` takes precedence.
 externalMongodb:
   url: ""
+  existingSecret: ""
+  secretKey: "connectionString"
 
 persistence:
   enabled: true

--- a/README.md
+++ b/README.md
@@ -152,8 +152,7 @@ helm install genieacs genieacs/genieacs \
   --namespace genieacs \
   --create-namespace \
   --set mongodb.enabled=false \
-  --set externalMongodb.existingSecret=genieacs-mongodb \
-  --set externalMongodb.secretKey=connectionString
+  --set externalMongodb.existingSecret=genieacs-mongodb
 ```
 
 This pattern integrates with External Secrets Operator, Sealed Secrets,

--- a/charts/genieacs/templates/deployment.yaml
+++ b/charts/genieacs/templates/deployment.yaml
@@ -56,8 +56,8 @@ spec:
             - name: GENIEACS_MONGODB_CONNECTION_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.externalMongodb.existingSecret }}
-                  key: {{ .Values.externalMongodb.secretKey | default "connectionString" }}
+                  name: {{ .Values.externalMongodb.existingSecret | quote }}
+                  key: {{ .Values.externalMongodb.secretKey | quote }}
             {{- else if .Values.externalMongodb.url }}
             - name: GENIEACS_MONGODB_CONNECTION_URL
               value: "{{ .Values.externalMongodb.url }}"

--- a/charts/genieacs/templates/deployment.yaml
+++ b/charts/genieacs/templates/deployment.yaml
@@ -52,6 +52,12 @@ spec:
             {{- else if .Values.mongodb.enabled }}
             - name: GENIEACS_MONGODB_CONNECTION_URL
               value: "mongodb://{{ include "genieacs.mongodb.fullname" . }}:27017/genieacs"
+            {{- else if .Values.externalMongodb.existingSecret }}
+            - name: GENIEACS_MONGODB_CONNECTION_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalMongodb.existingSecret }}
+                  key: {{ .Values.externalMongodb.secretKey | default "connectionString" }}
             {{- else if .Values.externalMongodb.url }}
             - name: GENIEACS_MONGODB_CONNECTION_URL
               value: "{{ .Values.externalMongodb.url }}"

--- a/charts/genieacs/values.schema.json
+++ b/charts/genieacs/values.schema.json
@@ -183,7 +183,8 @@
           "type": "string"
         },
         "existingSecret": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
         },
         "secretKey": {
           "type": "string"

--- a/charts/genieacs/values.schema.json
+++ b/charts/genieacs/values.schema.json
@@ -181,6 +181,12 @@
       "properties": {
         "url": {
           "type": "string"
+        },
+        "existingSecret": {
+          "type": "string"
+        },
+        "secretKey": {
+          "type": "string"
         }
       }
     },

--- a/charts/genieacs/values.schema.json
+++ b/charts/genieacs/values.schema.json
@@ -184,10 +184,14 @@
         },
         "existingSecret": {
           "type": "string",
+          "maxLength": 253,
           "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
         },
         "secretKey": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 253,
+          "pattern": "^[-._A-Za-z0-9]+$"
         }
       }
     },

--- a/charts/genieacs/values.yaml
+++ b/charts/genieacs/values.yaml
@@ -73,10 +73,25 @@ mongodb:
     enabled: true
     size: 8Gi
 
-# Used when mongodb.enabled is false (bring your own MongoDB)
-# Must include credentials if the external MongoDB requires auth
+# Used when mongodb.enabled is false (bring your own MongoDB).
+# Recommended for production. The bundled MongoDB subchart is intended
+# for development and evaluation only.
+#
+# Provide connection details either:
+#   a) directly via `url` (connection string includes credentials), or
+#   b) via `existingSecret` + `secretKey`, which reads the connection
+#      string from a Kubernetes Secret at pod start using valueFrom.
+#      This is the right path for production because credentials stay
+#      out of values files and out of the pod spec, and it integrates
+#      with External Secrets Operator, Sealed Secrets, Vault, MongoDB
+#      Atlas Operator, MongoDB Controllers for Kubernetes (MCK), the
+#      Percona Operator, etc.
+#
+# If both are set, `existingSecret` takes precedence.
 externalMongodb:
   url: ""
+  existingSecret: ""
+  secretKey: "connectionString"
 
 persistence:
   enabled: true


### PR DESCRIPTION
## Summary

Extends external MongoDB configuration so the connection string can be
sourced from a Kubernetes Secret at pod start via `valueFrom.secretKeyRef`,
instead of inlining it in values. Keeps credentials out of values files
and the pod spec, and integrates with External Secrets Operator, Sealed
Secrets, Vault, and operators that write connection details to a Secret
(MongoDB Atlas Operator, MongoDB Controllers for Kubernetes, Percona
Operator for MongoDB).

Matches the scope discussed in #51.

## Changes

- **`values.yaml`** — Add `externalMongodb.existingSecret` and
  `externalMongodb.secretKey` (defaults: `""`, `"connectionString"`).
  Expand the inline comment to explain when to use each and note that
  the bundled MongoDB subchart is for dev/evaluation only.
- **`values.schema.json`** — Declare the two new string properties on
  `externalMongodb`.
- **`templates/deployment.yaml`** — Insert a new `else if` branch that
  uses `secretKeyRef` when `existingSecret` is set. Precedence is
  `existingSecret` > `url`, so a deployment that sets both will not
  silently leak the inline URL.
- **`README.md`** — Add a third `helm install` example using
  `existingSecret`, add a production-deployment note making clear the
  bundled Bitnami MongoDB is for development/evaluation only, and
  update the `values.yaml` snippet to show the new keys.

## Compatibility

No functional change for existing deployments. Defaults are empty and
all existing branches render identically. Verified with `helm template`:

| Mode | Rendering |
|---|---|
| Bundled, no auth (default) | unchanged — `mongodb://<release>-mongodb:27017/genieacs` |
| Bundled + auth + rootPassword | unchanged — `urlquery`-encoded password |
| Bundled + auth, auto-generated password | unchanged — `secretKeyRef` to subchart secret |
| `externalMongodb.url` set | unchanged — inline value |
| `externalMongodb.existingSecret` set | **new** — `valueFrom.secretKeyRef` |
| Both `url` and `existingSecret` set | `existingSecret` wins |

## Test plan

- [x] `helm lint charts/genieacs` passes
- [x] `helm template` covers all 6 rendering modes above
- [x] URL-encoding of special characters in `rootPassword` still works
      (no regression)
- [ ] Maintainer review

Closes #51.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for sourcing MongoDB connection strings from a Kubernetes Secret (configurable secret name and key). Secret-backed configuration takes precedence over an inline URL.

* **Documentation**
  * Expanded Helm chart docs with production-oriented guidance for using an external MongoDB, clarifying the bundled DB is for development/evaluation and noting default secret key: "connectionString".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->