### PR TITLE
ci: use GitHub-hosted ubuntu-latest runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,7 @@ env:
 
 jobs:
   test:
-    runs-on: [self-hosted, Linux, X64]
-    # Do not run untrusted fork PR code on the self-hosted runner.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     # NOTE: We intentionally do NOT use `services:` here. On the shared
     # self-hosted runner host, the Actions runner auto-creates a bridge
     # network for service containers, drawing a subnet from Docker's default
@@ -95,7 +91,7 @@ jobs:
   release:
     needs: test
     if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
@@ -124,11 +120,7 @@ jobs:
 
   build-amd64:
     needs: release
-    runs-on: [self-hosted, Linux, X64]
-    # Do not run untrusted fork PR code on the self-hosted runner.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -152,11 +144,7 @@ jobs:
 
   build-arm64:
     needs: release
-    runs-on: [self-hosted, Linux, ARM64]
-    # Do not run untrusted fork PR code on the self-hosted runner.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -180,11 +168,7 @@ jobs:
 
   manifest:
     needs: [release, build-amd64, build-arm64]
-    runs-on: [self-hosted, Linux, X64]
-    # Do not run untrusted fork PR code on the self-hosted runner.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -14,7 +14,7 @@ jobs:
   release:
     permissions:
       contents: write
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10
         with:

--- a/.github/workflows/upstream-check.yml
+++ b/.github/workflows/upstream-check.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-upstream:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Switches self-hosted Linux CI jobs to GitHub-hosted `ubuntu-latest`.

## Why
GitHub-hosted standard runners are **free and unlimited on public repos**. Moving CI off the home-lab self-hosted runners:
- frees my servers from CI load,
- runs PR code in throwaway isolated VMs (removes the fork-PR attack surface entirely),
- costs $0 on public repos.

The earlier self-hosted fork-guard `if:` is removed (no longer needed on hosted runners). Any macOS/Windows self-hosted jobs (desktop builds) are left unchanged.
