### PR TITLE
feat(chart): add Gateway API HTTPRoute support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## Helm Chart [0.5.0] - 2026-08-01
+
+### Added
+- **Gateway API `HTTPRoute` support** — the UI service can now be exposed through a Gateway API `HTTPRoute` as an alternative to `Ingress`. Disabled by default; set `httpRoute.enabled=true` and provide `httpRoute.parentRefs`. Supports `annotations`, `parentRefs`, `hostnames`, and path `matches` (#60, thanks @mool)
+- **`values.schema.json` validation for `httpRoute`** — enabling the route without `parentRefs` or `matches` now fails at template time with a clear message instead of rendering an unusable resource
+- **NOTES.txt lists both access paths** — Ingress and HTTPRoute hosts are now printed separately when either is enabled
+
 ## Helm Chart [0.3.4] - 2026-03-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ ingress:
 
 # Kubernetes Gateway API alternative to `ingress` (requires the
 # Gateway API CRDs and a Gateway controller in the cluster).
-# `parentRefs` is required when enabled.
+# `parentRefs` and `matches` are both required when enabled.
 httpRoute:
   enabled: false
   parentRefs: []
@@ -202,6 +202,10 @@ httpRoute:
   #   sectionName: https
   hostnames:
     - genieacs.local
+  matches:
+    - path:
+        type: PathPrefix
+        value: /
 
 env:
   GENIEACS_UI_JWT_SECRET: changeme

--- a/README.md
+++ b/README.md
@@ -191,6 +191,18 @@ ingress:
   enabled: false
   className: ""  # e.g. "nginx", "traefik"
 
+# Kubernetes Gateway API alternative to `ingress` (requires the
+# Gateway API CRDs and a Gateway controller in the cluster).
+# `parentRefs` is required when enabled.
+httpRoute:
+  enabled: false
+  parentRefs: []
+  # - name: my-gateway
+  #   namespace: gateway-system
+  #   sectionName: https
+  hostnames:
+    - genieacs.local
+
 env:
   GENIEACS_UI_JWT_SECRET: changeme
 

--- a/charts/genieacs/Chart.yaml
+++ b/charts/genieacs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: genieacs
 description: A Helm chart for GenieACS - an open-source implementation of TR-069 ACS
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "1.2.16.0"
 keywords:
   - genieacs

--- a/charts/genieacs/templates/NOTES.txt
+++ b/charts/genieacs/templates/NOTES.txt
@@ -16,6 +16,8 @@ GenieACS has been deployed successfully!
    HTTPRoute host/path:
    {{- range .Values.httpRoute.hostnames }}
      {{ . }}{{ (index $.Values.httpRoute.matches 0).path.value }}
+   {{- else }}
+     (any hostname accepted by the Gateway listener){{ (index $.Values.httpRoute.matches 0).path.value }}
    {{- end }}
    {{- end }}
 {{- else }}

--- a/charts/genieacs/templates/NOTES.txt
+++ b/charts/genieacs/templates/NOTES.txt
@@ -2,14 +2,24 @@ GenieACS has been deployed successfully!
 
 1. To access the GenieACS UI, follow these instructions:
 
-{{- if .Values.ingress.enabled }}
-   The GenieACS UI is accessible at:
+{{- if or .Values.ingress.enabled .Values.httpRoute.enabled }}
+   The GenieACS UI is accessible through the configured route resource(s):
 
+   {{- if .Values.ingress.enabled }}
+   Ingress:
    {{- range .Values.ingress.hosts }}
      http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{ (index .paths 0).path }}
    {{- end }}
+   {{- end }}
+
+   {{- if .Values.httpRoute.enabled }}
+   HTTPRoute:
+   {{- range .Values.httpRoute.hostnames }}
+     http://{{ . }}{{ (index $.Values.httpRoute.matches 0).path.value }}
+   {{- end }}
+   {{- end }}
 {{- else }}
-   NOTE: The ingress is disabled, and you might need to use port-forwarding to access the UI.
+   NOTE: The ingress and HTTPRoute are disabled, and you might need to use port-forwarding to access the UI.
 
    Run the following command to forward the port:
 

--- a/charts/genieacs/templates/NOTES.txt
+++ b/charts/genieacs/templates/NOTES.txt
@@ -13,9 +13,9 @@ GenieACS has been deployed successfully!
    {{- end }}
 
    {{- if .Values.httpRoute.enabled }}
-   HTTPRoute:
+   HTTPRoute host/path:
    {{- range .Values.httpRoute.hostnames }}
-     http://{{ . }}{{ (index $.Values.httpRoute.matches 0).path.value }}
+     {{ . }}{{ (index $.Values.httpRoute.matches 0).path.value }}
    {{- end }}
    {{- end }}
 {{- else }}

--- a/charts/genieacs/templates/httproute.yaml
+++ b/charts/genieacs/templates/httproute.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "genieacs.fullname" . }}
+  labels:
+    {{- include "genieacs.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- toYaml .Values.httpRoute.matches | nindent 8 }}
+      backendRefs:
+        - name: {{ include "genieacs.fullname" . }}-http
+          port: {{ .Values.service_http.port_http }}
+{{- end }}

--- a/charts/genieacs/values.schema.json
+++ b/charts/genieacs/values.schema.json
@@ -124,6 +124,26 @@
     },
     "httpRoute": {
       "type": "object",
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            },
+            "required": ["enabled"]
+          },
+          "then": {
+            "required": ["parentRefs"],
+            "properties": {
+              "parentRefs": {
+                "minItems": 1
+              }
+            }
+          }
+        }
+      ],
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -134,7 +154,14 @@
         "parentRefs": {
           "type": "array",
           "items": {
-            "type": "object"
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
           }
         },
         "hostnames": {

--- a/charts/genieacs/values.schema.json
+++ b/charts/genieacs/values.schema.json
@@ -122,6 +122,51 @@
         }
       }
     },
+    "httpRoute": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "parentRefs": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "hostnames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "matches": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["path"],
+            "properties": {
+              "path": {
+                "type": "object",
+                "required": ["type", "value"],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "env": {
       "type": "object",
       "additionalProperties": {

--- a/charts/genieacs/values.schema.json
+++ b/charts/genieacs/values.schema.json
@@ -135,7 +135,7 @@
             "required": ["enabled"]
           },
           "then": {
-            "required": ["parentRefs"],
+            "required": ["parentRefs", "matches"],
             "properties": {
               "parentRefs": {
                 "minItems": 1

--- a/charts/genieacs/values.yaml
+++ b/charts/genieacs/values.yaml
@@ -32,6 +32,17 @@ ingress:
           pathType: ImplementationSpecific
   tls: []
 
+httpRoute:
+  enabled: false
+  annotations: {}
+  parentRefs: []
+  hostnames:
+    - genieacs.local
+  matches:
+    - path:
+        type: PathPrefix
+        value: /
+
 env:
   GENIEACS_UI_JWT_SECRET: changeme
   GENIEACS_CWMP_ACCESS_LOG_FILE: /var/log/genieacs/genieacs-cwmp-access.log


### PR DESCRIPTION
## Summary
- add optional Gateway API HTTPRoute support for the GenieACS UI service
- add values and schema entries for HTTPRoute configuration
- update Helm NOTES and bump chart version

## Verification
- git diff --check
- helm lint charts/genieacs
- helm template test-release charts/genieacs --set httpRoute.enabled=true


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Kubernetes Gateway API HTTPRoute support for exposing the application.
  * HTTPRoute settings include annotations, parent references, hostnames, path matching, and backend configuration.
  * HTTPRoute exposure is disabled by default and can be enabled through chart values.

* **Documentation**
  * Updated deployment notes to display access URLs for enabled Ingress and HTTPRoute resources.
  * Added HTTPRoute configuration guidance and clarified disabled-access messaging.
  * Added chart 0.5.0 changelog details.

* **Chores**
  * Added validation for required HTTPRoute configuration.
  * Updated the Helm chart version to 0.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->